### PR TITLE
fix: Fixes #15 UnicodeDecodeError in FBX export by specifying UTF-8 e…

### DIFF
--- a/nodes/processing/export.py
+++ b/nodes/processing/export.py
@@ -294,7 +294,7 @@ class SAM3DBodyExportFBX:
                     cmd.append(skeleton_json_path)
 
                 print(f"[SAM3DBodyExportFBX] Running Blender export...")
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=BLENDER_TIMEOUT)
+                result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', timeout=BLENDER_TIMEOUT)
 
                 # Always print stdout to see debug info
                 if result.stdout:


### PR DESCRIPTION
Fix UnicodeDecodeError in FBX export (#15)

When exporting FBX models via the Blender subprocess, a UnicodeDecodeError occurs in environments where the default system encoding is ASCII (e.g., some Linux containers). This happens because subprocess.run(..., text=True) uses the locale’s default encoding, but Blender’s output may contain UTF-8 characters (e.g., en-dashes or non-ASCII paths).

Fix: Explicitly specify encoding='utf-8' in the subprocess.run() call to safely handle all valid output from Blender.

Resolves #15.